### PR TITLE
Deserialization Exception improvements

### DIFF
--- a/src/Turbocharged.Beanstalk/BeanstalkConnection.cs
+++ b/src/Turbocharged.Beanstalk/BeanstalkConnection.cs
@@ -297,16 +297,20 @@ namespace Turbocharged.Beanstalk
 
         #region Consumer
 
-        Task<Job> IConsumer.ReserveAsync(TimeSpan timeout)
+        private Task<Job> ReserveAsync(TimeSpan? timeout)
         {
             var request = new ReserveRequest(timeout);
             return SendAndGetResult(request);
         }
 
+        Task<Job> IConsumer.ReserveAsync(TimeSpan timeout)
+        {
+            return ReserveAsync((TimeSpan?)timeout);
+        }
+
         Task<Job> IConsumer.ReserveAsync()
         {
-            var request = new ReserveRequest();
-            return SendAndGetResult(request);
+            return ReserveAsync(null);
         }
 
         /// <summary>

--- a/src/Turbocharged.Beanstalk/IConsumer.cs
+++ b/src/Turbocharged.Beanstalk/IConsumer.cs
@@ -44,7 +44,7 @@ namespace Turbocharged.Beanstalk
         Task<Job> ReserveAsync(TimeSpan timeout);
 
         /// <summary>
-        /// Retrives a job without reserving it.
+        /// Retrieves a job without reserving it.
         /// </summary>
         /// <returns>A job, or null if the job was not found.</returns>
         Task<Job> PeekAsync(int id);

--- a/src/Turbocharged.Beanstalk/Reserve.cs
+++ b/src/Turbocharged.Beanstalk/Reserve.cs
@@ -14,7 +14,7 @@ namespace Turbocharged.Beanstalk
         TaskCompletionSource<Job> _tcs = new TaskCompletionSource<Job>();
         TimeSpan? _timeout;
 
-        public ReserveRequest(TimeSpan timeout)
+        public ReserveRequest(TimeSpan? timeout)
         {
             _timeout = timeout;
         }


### PR DESCRIPTION
When a ReserveAsync<T> deserialization failed, the job was reserved, but
the caller did not receive the Job Id, so the caller could not resolve
the error. Now a custom DeserializationException is thrown that has a
Job property. The job is left reserved, but the caller can catch the
exception and use its Job property to resolve the error as they desire:
log the error, send notifications, release/bury/delete the job,
deserialize the data to a different object, etc. Also, to improve code
reuse, a few primary private overloads were added for the other
overloads to call.
